### PR TITLE
workaround if no didDoc is returned by createSession

### DIFF
--- a/src/BlueskyApi.php
+++ b/src/BlueskyApi.php
@@ -83,7 +83,7 @@ class BlueskyApi
 	 */
 	public function getSessionHost(): ?string
 	{
-		if (($this->activeSession) && (is_array($this->activeSession->didDoc->service))) {
+		if (($this->activeSession) && isset($this->activeSession->didDoc) && (is_array($this->activeSession->didDoc->service))) {
 			foreach ($this->activeSession->didDoc->service AS $service) {
 				if (!empty($service->serviceEndpoint)) {
 					return $this->sanitizeApiHost($service->serviceEndpoint);
@@ -91,7 +91,7 @@ class BlueskyApi
 			}
 		}
 
-		return null;
+		return $this->defaultApiHost;
 	}
 
 	/**


### PR DESCRIPTION
It may happen that com.atproto.server.createSession returns no didDoc (I honestly don't know why it happens), in this case the getSessionHost function fails.
This workaround fixes this issue.